### PR TITLE
[Fix/#16] User권한 관련 필드 타입 변경

### DIFF
--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/entity/Level.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/entity/Level.java
@@ -1,0 +1,5 @@
+package com.shinhan_hackathon.the_family_guardian.domain.user.entity;
+
+public enum Level {
+    SUPPORTER, GUARDIAN
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/entity/Role.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/entity/Role.java
@@ -1,0 +1,5 @@
+package com.shinhan_hackathon.the_family_guardian.domain.user.entity;
+
+public enum Role {
+    NONE, MEMBER, MANAGER, OWNER
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/entity/User.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/entity/User.java
@@ -4,16 +4,7 @@ import java.util.Date;
 
 import com.shinhan_hackathon.the_family_guardian.domain.family.entity.Family;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,7 +44,8 @@ public class User {
 	private String accountNumber;
 
 	@Column(length = 20, nullable = false, columnDefinition = "varchar(20) default 'supporter'")
-	private String role;
+	@Enumerated(EnumType.STRING)
+	private Level level;
 
 	@ManyToOne
 	@JoinColumn(name = "family_id", nullable = true)
@@ -63,12 +55,13 @@ public class User {
 	private String relationship; // 가족 관계
 
 	@Column(length = 20, nullable = false, columnDefinition = "varchar(20) default 'member'")
-	private String authority; // 패밀리 내부 권한: 'member' 또는 'guardian'
+	@Enumerated(EnumType.STRING)
+	private Role role; // 패밀리 내부 권한: 'member' 또는 'guardian'
 
 
 	@Builder
 	public User(String username, String password, String name, String gender, Date birthDate, String phone,
-				String accountNumber, String role, Family family, String relationship, String authority) {
+				String accountNumber, Level level, Family family, String relationship, Role role) {
 		this.username = username;
 		this.password = password;
 		this.name = name;
@@ -76,9 +69,9 @@ public class User {
 		this.birthDate = birthDate;
 		this.phone = phone;
 		this.accountNumber = accountNumber;
-		this.role = role;
+		this.level = level;
 		this.family = family;
 		this.relationship = relationship;
-		this.authority = authority;
+		this.role = role;
 	}
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/global/auth/dto/UserPrinciple.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/global/auth/dto/UserPrinciple.java
@@ -2,11 +2,10 @@ package com.shinhan_hackathon.the_family_guardian.global.auth.dto;
 
 import com.shinhan_hackathon.the_family_guardian.domain.user.entity.User;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 
 public record UserPrinciple (
         User user
@@ -14,7 +13,10 @@ public record UserPrinciple (
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singletonList(new SimpleGrantedAuthority(user.getRole().name()));
+        Collection<GrantedAuthority> authList = new ArrayList<>();
+        authList.add(() -> user.getLevel().name());
+        authList.add(() -> user.getRole().name());
+        return authList;
     }
 
     @Override

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/global/auth/dto/UserPrinciple.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/global/auth/dto/UserPrinciple.java
@@ -14,7 +14,7 @@ public record UserPrinciple (
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singletonList(new SimpleGrantedAuthority(user.getAuthority()));
+        return Collections.singletonList(new SimpleGrantedAuthority(user.getRole().name()));
     }
 
     @Override

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/global/auth/dto/UserPrinciple.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/global/auth/dto/UserPrinciple.java
@@ -24,10 +24,6 @@ public record UserPrinciple (
 
     @Override
     public String getUsername() {
-        return user.getUsername();
-    }
-
-    public Long getId() {
-        return user.getId();
+        return String.valueOf(user.getId());
     }
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/global/auth/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/global/auth/service/UserDetailsServiceImpl.java
@@ -21,7 +21,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User Not Found"));
 
-        if (!StringUtils.hasText(user.getAuthority())) {
+        if (user.getRole() == null) {
             throw new UsernameNotFoundException("User Authority Not Found");
         }
 


### PR DESCRIPTION
## 연결 이슈 <!-- 연결 이슈 번호를 작성해주세요. Ex. tomato-market/plan#3)  -->

- resolve: #16 

## 요약 <!-- 현재 PR의 요약 내용을 작성해주세요. -->

- String보다 안전한 Enum을 사용하여 유저 권한설정 진행

## 변경 내용 <!-- 현재 PR의 변경 내용을 작성해주세요. -->

- 유저 권한과 관련된 필드의 이름 수정.
- 유저 권환 필드의 타입을 Enum으로 수정