### PR TITLE
[Fix/#32] dotenv import문 제거

### DIFF
--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/bank/service/AccountAuthService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/bank/service/AccountAuthService.java
@@ -5,7 +5,6 @@ import com.shinhan_hackathon.the_family_guardian.bank.dto.request.*;
 import com.shinhan_hackathon.the_family_guardian.bank.dto.response.CheckAuthCodeResponse;
 import com.shinhan_hackathon.the_family_guardian.bank.dto.response.OpenAccountAuthResponse;
 import com.shinhan_hackathon.the_family_guardian.bank.util.BankUtil;
-import io.github.cdimascio.dotenv.Dotenv;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;


### PR DESCRIPTION
## 연결 이슈 <!-- 연결 이슈 번호를 작성해주세요. Ex. tomato-market/plan#3)  -->

- resolve: #32

## 요약 <!-- 현재 PR의 요약 내용을 작성해주세요. -->

- AccountAuthService에서 제거되지 않았던 dotenv import제거

