### PR TITLE
[Feat/#48] 승인 거절 로직 및 알림 추가

### DIFF
--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/controller/NotificationController.java
@@ -1,0 +1,28 @@
+package com.shinhan_hackathon.the_family_guardian.domain.notification.controller;
+
+import com.shinhan_hackathon.the_family_guardian.domain.notification.dto.NotificationReplyRequest;
+import com.shinhan_hackathon.the_family_guardian.domain.notification.dto.NotificationReplyResponse;
+import com.shinhan_hackathon.the_family_guardian.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/notification")
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @PostMapping("/reply")
+    public ResponseEntity<NotificationReplyResponse> postGuardianReply(@RequestBody NotificationReplyRequest notificationReplyRequest) {
+        NotificationReplyResponse notificationReplyResponse = notificationService.reflectReply(
+                notificationReplyRequest.notificationId(),
+                notificationReplyRequest.isApprove()
+        );
+
+        return ResponseEntity.ok(notificationReplyResponse);
+    }
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/dto/NotificationReplyRequest.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/dto/NotificationReplyRequest.java
@@ -1,0 +1,7 @@
+package com.shinhan_hackathon.the_family_guardian.domain.notification.dto;
+
+public record NotificationReplyRequest(
+        Long notificationId,
+        Boolean isApprove
+) {
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/dto/NotificationReplyResponse.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/dto/NotificationReplyResponse.java
@@ -1,0 +1,11 @@
+package com.shinhan_hackathon.the_family_guardian.domain.notification.dto;
+
+import com.shinhan_hackathon.the_family_guardian.domain.transaction.entity.TransactionStatus;
+
+public record NotificationReplyResponse(
+        Long transactionId,
+        TransactionStatus transactionStatus,
+        Integer approveCount,
+        Integer rejectCount
+) {
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/service/NotificationService.java
@@ -1,13 +1,19 @@
 package com.shinhan_hackathon.the_family_guardian.domain.notification.service;
 
+import com.shinhan_hackathon.the_family_guardian.domain.notification.dto.NotificationReplyRequest;
+import com.shinhan_hackathon.the_family_guardian.domain.notification.dto.NotificationReplyResponse;
 import com.shinhan_hackathon.the_family_guardian.domain.notification.entity.Notification;
 import com.shinhan_hackathon.the_family_guardian.domain.notification.repository.NotificationRepository;
 import com.shinhan_hackathon.the_family_guardian.domain.transaction.dto.TransactionInfo;
 import com.shinhan_hackathon.the_family_guardian.domain.transaction.dto.NotificationBody;
+import com.shinhan_hackathon.the_family_guardian.domain.transaction.entity.TransactionStatus;
+import com.shinhan_hackathon.the_family_guardian.global.event.EventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -16,11 +22,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final EventPublisher eventPublisher;
 
     @Transactional
     public NotificationBody saveNotification(TransactionInfo transactionInfo) {
 
         NotificationBody notificationBody = new NotificationBody(
+                transactionInfo.transaction().getId(),
                 transactionInfo.transaction().getTransactionType(),
                 transactionInfo.user().getAccountNumber(),
                 transactionInfo.transaction().getReceiver(),
@@ -38,5 +46,59 @@ public class NotificationService {
 
         notificationRepository.save(notification);
         return notificationBody;
+    }
+
+    public NotificationReplyResponse reflectReply(Long notificationId, Boolean isApprove) {
+        /**
+         * 가디언의 응답을 반영
+         * isApprove == true -> 찬성 1증가
+         * isApprove == false -> 반대 1증가
+         */
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 알림입니다."));
+
+        String eventTrackingId = UUID.randomUUID().toString();
+        TransactionStatus transactionStatus = TransactionStatus.PENDING;
+        int approveCount = notification.getTransaction().getApproveCount();
+        int rejectCount = 1;    // TODO: notification.getTransaction.getRejectCount();
+
+        if (isApprove) {
+            // TODO: NotificationResponseStatus Entity의 response 업데이트
+            approveCount = notification.getTransaction().incrementApproveCount();
+            if (isUpToApprove(approveCount)) {
+                eventPublisher.publishTransactionApproveEvent(eventTrackingId, notificationId);
+                transactionStatus = TransactionStatus.APPROVE;
+            }
+        } else {
+            // TODO: NotificationResponseStatus Entity의 response 업데이트
+            rejectCount = 1;    // TODO: 거절횟수도 기록
+            if (isUpToReject(rejectCount)) {
+                eventPublisher.publishTransactionRejectEvent(eventTrackingId, notificationId);
+                transactionStatus = TransactionStatus.REJECT;
+            }
+        }
+
+        return new NotificationReplyResponse(
+                notification.getTransaction().getId(),
+                transactionStatus,
+                approveCount,
+                rejectCount
+        );
+
+    }
+
+    /**
+     * 구현 설명을 위한 메서드
+     */
+    private boolean isUpToApprove(int approveCnt) {
+        int threshold = 3;
+        return approveCnt >= 3;
+    }
+    /**
+     * 구현 설명을 위한 메서드
+     */
+    private boolean isUpToReject(int rejectCnt) {
+        int threshold = 3;
+        return rejectCnt >= 3;
     }
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/dto/NotificationBody.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/dto/NotificationBody.java
@@ -3,6 +3,7 @@ package com.shinhan_hackathon.the_family_guardian.domain.transaction.dto;
 import com.shinhan_hackathon.the_family_guardian.domain.transaction.entity.TransactionType;
 
 public record NotificationBody(
+        Long notificationId,
         TransactionType transactionType,
         String senderAccountNumber,
         String receiver,

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/entity/Transaction.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/entity/Transaction.java
@@ -51,6 +51,10 @@ public class Transaction {
         return ++this.rejectCount;
     }
 
+    public TransactionStatus updateTransactionStatus(TransactionStatus transactionStatus) {
+        return this.status = transactionStatus;
+    }
+
     @Builder
     public Transaction(User user, TransactionType transactionType, Long transactionBalance, Timestamp timestamp, TransactionStatus status, int approveCount, String receiver) {
         this.user = user;

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/entity/Transaction.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/entity/Transaction.java
@@ -44,8 +44,8 @@ public class Transaction {
 
     private String receiver;
 
-    public void incrementApproveCount() {
-        this.approveCount++;
+    public int incrementApproveCount() {
+        return ++this.approveCount;
     }
     public void incrementRejectCount() {
         this.rejectCount++;

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/entity/Transaction.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/entity/Transaction.java
@@ -47,8 +47,8 @@ public class Transaction {
     public int incrementApproveCount() {
         return ++this.approveCount;
     }
-    public void incrementRejectCount() {
-        this.rejectCount++;
+    public int incrementRejectCount() {
+        return ++this.rejectCount;
     }
 
     @Builder

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/service/TransactionService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/service/TransactionService.java
@@ -19,9 +19,14 @@ import com.shinhan_hackathon.the_family_guardian.global.auth.dto.UserPrincipal;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
+
+import com.shinhan_hackathon.the_family_guardian.global.event.PaymentApproveEvent;
+import com.shinhan_hackathon.the_family_guardian.global.event.TransferApproveEvent;
+import com.shinhan_hackathon.the_family_guardian.global.event.WithdrawalApproveEvent;
 import com.shinhan_hackathon.the_family_guardian.global.fcm.FcmSender;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -270,10 +275,11 @@ public class TransactionService {
 
 
     // TODO: 승인 요구치에 따른 출금 진행
-    public void executeWithdrawalTransaction(Long transactionId) {
+    @EventListener(WithdrawalApproveEvent.class)
+    public void executeWithdrawalTransaction(WithdrawalApproveEvent event) {
         log.info("TransactionService.executeWithdrawalTransaction() is called.");
         // Transaction 정보 조회
-        Transaction transaction = transactionRepository.findById(transactionId)
+        Transaction transaction = transactionRepository.findById(event.getTransactionId())
                 .orElseThrow(() -> new RuntimeException("Transaction Not Found."));
         User user = transaction.getUser();
         Integer approvalRequirement = user.getFamily().getApprovalRequirement(); // 승인 요구치
@@ -290,17 +296,18 @@ public class TransactionService {
     }
 
     // TODO: 승인 요구치에 따른 이체 진행 - DepositAccountNo를 받아야함, 수정 있을 수 있음
-    public void executeTransferTransaction(Long transactionId, String depositAccountNo) {
+    @EventListener(TransferApproveEvent.class)
+    public void executeTransferTransaction(TransferApproveEvent event) {
         log.info("TransactionService.executeTransferTransaction() is called.");
         // Transaction 정보 조회
-        Transaction transaction = transactionRepository.findById(transactionId)
+        Transaction transaction = transactionRepository.findById(event.getTransactionId())
                 .orElseThrow(() -> new RuntimeException("Transaction Not Found."));
         User user = transaction.getUser();
         Integer approvalRequirement = user.getFamily().getApprovalRequirement(); // 승인 요구치
 
         if(transaction.getApproveCount() >= approvalRequirement) { // 승인 요구치에 도달하면
             // 이체
-            accountService.updateAccountTransfer(depositAccountNo, user.getAccountNumber(), transaction.getTransactionBalance());
+            accountService.updateAccountTransfer(transaction.getReceiver(), user.getAccountNumber(), transaction.getTransactionBalance());
             fcmSender.sendTransferSuccessMessage(user.getDeviceToken(), user.getAccountNumber(), transaction.getReceiver() ,transaction.getTransactionBalance());
             log.info("Success to execute transfer.");
         }
@@ -310,10 +317,11 @@ public class TransactionService {
     }
 
     // TODO: 승인 요구치에 따른 결제 진행
-    public void executePaymentTransaction(Long transactionId) {
+    @EventListener(PaymentApproveEvent.class)
+    public void executePaymentTransaction(PaymentApproveEvent event) {
         log.info("TransactionService.executePaymentTransaction() is called.");
         // Transaction 정보 조회
-        Transaction transaction = transactionRepository.findById(transactionId)
+        Transaction transaction = transactionRepository.findById(event.getTransactionId())
                 .orElseThrow(() -> new RuntimeException("Transaction Not Found."));
         User user = transaction.getUser();
         Integer approvalRequirement = user.getFamily().getApprovalRequirement(); // 승인 요구치

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/global/event/EventPublisher.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/global/event/EventPublisher.java
@@ -1,0 +1,25 @@
+package com.shinhan_hackathon.the_family_guardian.global.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class EventPublisher {
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void publishTransactionApproveEvent(String eventId, Long transactionId) {
+        log.info("[Publish Approve Event] Event-ID: {}", eventId);
+        TransactionApproveEvent transactionApproveEvent = new TransactionApproveEvent(this, eventId, transactionId);
+        eventPublisher.publishEvent(transactionApproveEvent);
+    }
+
+    public void publishTransactionRejectEvent(String eventId, Long transactionId) {
+        log.info("[Publish Reject Event] Event-ID: {}", eventId);
+        TransactionRejectEvent transactionRejectEvent = new TransactionRejectEvent(this, eventId, transactionId);
+        eventPublisher.publishEvent(transactionRejectEvent);
+    }
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/global/event/PaymentApproveEvent.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/global/event/PaymentApproveEvent.java
@@ -1,0 +1,7 @@
+package com.shinhan_hackathon.the_family_guardian.global.event;
+
+public class PaymentApproveEvent extends TransactionApproveEvent {
+    public PaymentApproveEvent(Object source, String eventId, Long transactionId) {
+        super(source, eventId, transactionId);
+    }
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/global/event/TransactionApproveEvent.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/global/event/TransactionApproveEvent.java
@@ -1,0 +1,7 @@
+package com.shinhan_hackathon.the_family_guardian.global.event;
+
+public class TransactionApproveEvent extends TransactionEvent {
+    public TransactionApproveEvent(Object source, String eventId, Long transactionId) {
+        super(source, eventId, transactionId);
+    }
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/global/event/TransactionEvent.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/global/event/TransactionEvent.java
@@ -1,0 +1,17 @@
+package com.shinhan_hackathon.the_family_guardian.global.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+abstract class TransactionEvent extends ApplicationEvent {
+
+    private final String eventId;
+    private final Long transactionId;
+
+    public TransactionEvent(Object source, String eventId, Long transactionId) {
+        super(source);
+        this.eventId = eventId;
+        this.transactionId = transactionId;
+    }
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/global/event/TransactionRejectEvent.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/global/event/TransactionRejectEvent.java
@@ -1,0 +1,7 @@
+package com.shinhan_hackathon.the_family_guardian.global.event;
+
+public class TransactionRejectEvent extends TransactionEvent {
+    public TransactionRejectEvent(Object source, String eventId, Long transactionId) {
+        super(source, eventId, transactionId);
+    }
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/global/event/TransferApproveEvent.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/global/event/TransferApproveEvent.java
@@ -1,0 +1,7 @@
+package com.shinhan_hackathon.the_family_guardian.global.event;
+
+public class TransferApproveEvent extends TransactionApproveEvent {
+    public TransferApproveEvent(Object source, String eventId, Long transactionId) {
+        super(source, eventId, transactionId);
+    }
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/global/event/WithdrawalApproveEvent.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/global/event/WithdrawalApproveEvent.java
@@ -1,0 +1,7 @@
+package com.shinhan_hackathon.the_family_guardian.global.event;
+
+public class WithdrawalApproveEvent extends TransactionApproveEvent {
+    public WithdrawalApproveEvent(Object source, String eventId, Long transactionId) {
+        super(source, eventId, transactionId);
+    }
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/global/fcm/FcmSender.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/global/fcm/FcmSender.java
@@ -120,6 +120,7 @@ public class FcmSender implements MessageSender {
     // FCM 전송 메서드
     private void sendTransactionResultMessage(String deviceToken, TransactionType txType, String senderAccount, String receiver, long transactionBalance, String txName, boolean isSuccess) {
         NotificationBody notificationBody = new NotificationBody(
+                0L,
                 txType,
                 senderAccount,
                 receiver,


### PR DESCRIPTION
## 연결 이슈 <!-- 연결 이슈 번호를 작성해주세요. Ex. tomato-market/plan#3)  -->

- #48 

## 요약 <!-- 현재 PR의 요약 내용을 작성해주세요. -->

- Response의 상태에 승인/거절 카운트 증가
- 카운트 증가 시 이벤트 발행, 각 카운트에 맞는 처리

## 변경 내용 <!-- 현재 PR의 변경 내용을 작성해주세요. -->

- TransationService
- NotificationService
- Event

## 기타 <!-- 기타 공유할 내용이 있다면 작성해주세요. -->

-
