### PR TITLE
[Feat/#56] 가족 내 유저의 역할변경 및 관리자 수 관리 구현

### DIFF
--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/controller/FamilyController.java
@@ -7,8 +7,6 @@ import com.shinhan_hackathon.the_family_guardian.domain.user.entity.Role;
 import com.shinhan_hackathon.the_family_guardian.global.auth.util.AuthUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -47,5 +45,17 @@ public class FamilyController {
 
         AddFamilyMemberResponse addFamilyMemberResponse = familyService.registerMember(family_id, addFamilyMemberRequest);
         return ResponseEntity.ok(addFamilyMemberResponse);
+    }
+
+    @PostMapping("/{family_id}/userRole")
+    public ResponseEntity updateFamilyUserRole(@PathVariable(value = "family_id") Long familyId, @RequestBody UpdateUserRoleRequest updateUserRoleRequest) {
+        authUtil.checkAuthority(Role.OWNER);
+        if (updateUserRoleRequest.newRole().equals(Role.NONE) ||
+        updateUserRoleRequest.newRole().equals(Role.OWNER)) {
+            throw new IllegalArgumentException("변경할 수 없는 가족 역할입니다.");
+        }
+
+        UpdateUserRoleResponse updateUserRoleResponse = familyService.manageFamilyUserRole(familyId, updateUserRoleRequest.targetUserId(), updateUserRoleRequest.newRole());
+        return ResponseEntity.ok(updateUserRoleResponse);
     }
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/UpdateUserRoleRequest.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/UpdateUserRoleRequest.java
@@ -1,0 +1,9 @@
+package com.shinhan_hackathon.the_family_guardian.domain.family.dto;
+
+import com.shinhan_hackathon.the_family_guardian.domain.user.entity.Role;
+
+public record UpdateUserRoleRequest (
+        Long targetUserId,
+        Role newRole
+) {
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/UpdateUserRoleResponse.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/UpdateUserRoleResponse.java
@@ -1,0 +1,9 @@
+package com.shinhan_hackathon.the_family_guardian.domain.family.dto;
+
+import com.shinhan_hackathon.the_family_guardian.domain.user.entity.Role;
+
+public record UpdateUserRoleResponse(
+        Long targetUserId,
+        Role newRole
+) {
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/entity/Family.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/entity/Family.java
@@ -30,14 +30,23 @@ public class Family {
     private List<User> users;
 
     @Column(nullable = false)
-    private int totalManagerCount; // TODO: Default로 Owner가 있으니까 1? default 0에서 그룹 생성할 때 owner 등록하면서 +1?
+    private Integer totalManagerCount; // TODO: Default로 Owner가 있으니까 1? default 0에서 그룹 생성할 때 owner 등록하면서 +1?
 
     @Builder
-    public Family(String name, String description, int approvalRequirement, List<User> users) {
+    public Family(String name, String description, int approvalRequirement, List<User> users, Integer totalManagerCount) {
         this.name = name;
         this.description = description;
         this.approvalRequirement = approvalRequirement;
         this.users = users;
+        this.totalManagerCount = totalManagerCount;
+    }
+
+    public int increaseTotalManagerCount() {
+        return ++this.totalManagerCount;
+    }
+
+    public int decreaseTotalManagerCount() {
+        return --this.totalManagerCount;
     }
 
     public String updateName(String name) {

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/repository/FamilyRepository.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/repository/FamilyRepository.java
@@ -1,7 +1,16 @@
 package com.shinhan_hackathon.the_family_guardian.domain.family.repository;
 
 import com.shinhan_hackathon.the_family_guardian.domain.family.entity.Family;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface FamilyRepository extends JpaRepository<Family, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select f from Family f where f.id = :id")
+    Optional<Family> findByIdForUpdate(Long id);
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
@@ -162,7 +162,8 @@ public class FamilyService {
         }
 
         User target = userService.getUser(targetUserId);
-        if (!target.getFamily().getId().equals(familyId)) {
+        if (target.getFamily() == null ||
+                !target.getFamily().getId().equals(familyId)) {
             throw new RuntimeException("같은 가족이 아닌 유저입니다.");
         }
 

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -45,6 +46,7 @@ public class FamilyService {
                 .description(createFamilyRequest.description())
                 .approvalRequirement(createFamilyRequest.approvalRequirement())
                 .users(new ArrayList<>(List.of(user)))
+                .totalManagerCount(1)
                 .build();
 
         Family savedFamily = familyRepository.save(family);
@@ -148,5 +150,41 @@ public class FamilyService {
                 user.getPhone(),
                 approvalId
         );
+    }
+
+    @Transactional
+    public UpdateUserRoleResponse manageFamilyUserRole(Long familyId, Long targetUserId, Role newRole) {
+        Long ownerId = Long.valueOf(authUtil.getUserPrincipal().getUsername());
+        User owner = userService.getUser(ownerId);
+        Family ownerFamily = owner.getFamily();
+        if (!ownerFamily.getId().equals(familyId)) {
+            throw new RuntimeException("소속된 가족이 아닙니다.");
+        }
+
+        User target = userService.getUser(targetUserId);
+        if (!target.getFamily().getId().equals(familyId)) {
+            throw new RuntimeException("같은 가족이 아닌 유저입니다.");
+        }
+
+        Role oldRole = target.getRole();
+        if (oldRole.equals(newRole)) {
+            throw new RuntimeException("기존 역할과 동일합니다.");
+        }
+
+        target.updateRole(newRole);
+
+        Family familyForUpdate = getFamilyForUpdate(familyId);
+        if (newRole.equals(Role.MEMBER)) {
+            familyForUpdate.decreaseTotalManagerCount();
+        } else {
+            familyForUpdate.increaseTotalManagerCount();
+        }
+
+        return new UpdateUserRoleResponse(targetUserId, newRole);
+    }
+
+    public Family getFamilyForUpdate(Long id) {
+        return familyRepository.findByIdForUpdate(id)
+                .orElseThrow(() -> new RuntimeException("해당 가족이 없습니다."));
     }
 }


### PR DESCRIPTION
## 연결 이슈 <!-- 연결 이슈 번호를 작성해주세요. Ex. tomato-market/plan#3)  -->

- resolve: #56 

## 요약 <!-- 현재 PR의 요약 내용을 작성해주세요. -->

- OWNER가 같은 가족 유저의 역할을 변경할 수 있는 API 구현
- 가족 구성원의 역할 변경에 따라 Family Entity의 관리자 수 변경

## 변경 내용 <!-- 현재 PR의 변경 내용을 작성해주세요. -->

- Family Entity 관리자 수 증감 메서드 생성
- Family Entity의 totalManagerCount타입 변경(primitive int -> Object Integer)
- 유저 역할 변경 api 추가
