### PR TITLE
[Feature/#67] 기간별 사용량 초기화

### DIFF
--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/payment/entity/PaymentLimit.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/payment/entity/PaymentLimit.java
@@ -1,10 +1,13 @@
 package com.shinhan_hackathon.the_family_guardian.domain.payment.entity;
 
+import jakarta.persistence.criteria.CriteriaBuilder.In;
 import java.sql.Timestamp;
 
 import com.shinhan_hackathon.the_family_guardian.domain.user.entity.User;
 
 import jakarta.persistence.*;
+import java.time.Instant;
+import java.time.ZoneId;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -58,6 +61,14 @@ public class PaymentLimit {
 
 	public Integer updateMaxLimitAmount(Integer maxLimitAmount) {
 		return this.maxLimitAmount = maxLimitAmount;
+	}
+
+	public void initializeAmountUsed() { // 누적 사용량을 0으로 초기화
+		this.amountUsed = 0;
+	}
+
+	public void initializeStartDate() {
+		this.startDate = Timestamp.from(Instant.now());
 	}
 
 

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/payment/service/PaymentLimitService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/payment/service/PaymentLimitService.java
@@ -6,8 +6,8 @@ import com.shinhan_hackathon.the_family_guardian.domain.payment.entity.PaymentLi
 import com.shinhan_hackathon.the_family_guardian.domain.payment.repository.PaymentLimitRepository;
 import com.shinhan_hackathon.the_family_guardian.domain.user.entity.User;
 import com.shinhan_hackathon.the_family_guardian.domain.user.repository.UserRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,7 +32,7 @@ public class PaymentLimitService {
         return (amount_used + transactionBalance) <= maxAmountLimit;
     }
 
-     // TODO: 단건 한도 확인
+    // TODO: 단건 한도 확인
     public boolean checkSingleTransactionLimit(Long userId, Long transactionBalance) {
         // Rule 조회
         User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User Not Found."));
@@ -61,5 +61,9 @@ public class PaymentLimitService {
                 paymentLimit.getSingleTransactionLimit(),
                 paymentLimit.getMaxLimitAmount()
         );
+    }
+
+    public List<PaymentLimit> findAllPaymentLimit() {
+        return paymentLimitRepository.findAll();
     }
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/service/TransactionService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/service/TransactionService.java
@@ -277,6 +277,7 @@ public class TransactionService {
 
     // TODO: 시간제한에 걸려 자동으로 요청 취소
     @Scheduled(fixedRate = 60000)
+    @Transactional
     public void updateTimeoutTransaction() {
         log.info("TransactionService.updateTimeoutTransaction() is called.");
         List<Transaction> transactionList = transactionRepository.findAllByStatus(TransactionStatus.PENDING);

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/service/TransactionService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/service/TransactionService.java
@@ -286,7 +286,7 @@ public class TransactionService {
         transactionList.stream()
         .filter(transaction -> {
            LocalDateTime transactionTime = LocalDateTime.ofInstant(transaction.getTimestamp().toInstant(), ZoneId.systemDefault());
-            Long minuteElapsed = ChronoUnit.MINUTES.between(transactionTime, now);
+            long minuteElapsed = ChronoUnit.MINUTES.between(transactionTime, now);
             return minuteElapsed > TIMEOUT;
         })
         .forEach(transaction -> {

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/service/UserService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/service/UserService.java
@@ -9,21 +9,22 @@ import com.shinhan_hackathon.the_family_guardian.bank.util.BankUtil;
 import com.shinhan_hackathon.the_family_guardian.domain.payment.entity.LimitPeriod;
 import com.shinhan_hackathon.the_family_guardian.domain.payment.entity.PaymentLimit;
 import com.shinhan_hackathon.the_family_guardian.domain.payment.repository.PaymentLimitRepository;
+import com.shinhan_hackathon.the_family_guardian.domain.payment.service.PaymentLimitService;
 import com.shinhan_hackathon.the_family_guardian.domain.user.dto.AccountAuthResponse;
 import com.shinhan_hackathon.the_family_guardian.domain.user.dto.SignupRequest;
-import com.shinhan_hackathon.the_family_guardian.domain.user.dto.UpdateDeviceTokenRequest;
 import com.shinhan_hackathon.the_family_guardian.domain.user.dto.UpdateDeviceTokenResponse;
 import com.shinhan_hackathon.the_family_guardian.domain.user.entity.User;
 import com.shinhan_hackathon.the_family_guardian.domain.user.repository.UserRepository;
 import com.shinhan_hackathon.the_family_guardian.global.auth.util.AuthUtil;
 import com.shinhan_hackathon.the_family_guardian.global.redis.service.RedisService;
-
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,6 +37,7 @@ public class UserService {
     public static final int MAX_LIMIT_AMOUNT_DEFAULT = 20_000_000;
 
     private final UserRepository userRepository;
+    private final PaymentLimitService paymentLimitService;
     private final AccountAuthService accountAuthService;
     private final AccountService accountService;
     private final RedisService redisService;
@@ -155,5 +157,23 @@ public class UserService {
 
         authUtil.updateAuthentication(user);
         return new UpdateDeviceTokenResponse(updatedDeviceToken);
+    }
+
+    // TODO: 매일 00시에 실행되는 AmountUsed 초기화
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 00:00에 실행
+    @Transactional
+    public void updateAmountUsed() {
+        log.info("UserService.updateAmountUsed() is called.");
+        List<PaymentLimit> paymentLimitList = paymentLimitService.findAllPaymentLimit();
+        paymentLimitList.stream().forEach(paymentLimit -> {
+            User user = paymentLimit.getUser();
+
+        });
+
+        // TODO: PaymentLimitList 조회
+        // TODO: 각 PaymentLimit의 User 조회
+        // TODO: 각 User의 period 조회
+        // TODO: 현재 날짜와 비교
+        // TODO: 정해진 period를 넘었으면, 초기화
     }
 }


### PR DESCRIPTION
## 연결 이슈 <!-- 연결 이슈 번호를 작성해주세요. Ex. tomato-market/plan#3)  -->

- #67 

## 요약 <!-- 현재 PR의 요약 내용을 작성해주세요. -->

- `@Scheduled`를 사용하여 매일 사용자의 룰 설정 기간을 확인
- 설정 기간이 지났다면, 사용량 초기화

## 변경 내용 <!-- 현재 PR의 변경 내용을 작성해주세요. -->

- `UserService.updateAmountUsed()`
- `PaymentLimit.initializeAmountUsed()`
- `PaymentLimit.initilaizeStartDate()`

## 기타 <!-- 기타 공유할 내용이 있다면 작성해주세요. -->

-
