### PR TITLE
[Feat/#72] 사용자 정보 조회 추가

### DIFF
--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/controller/UserController.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/controller/UserController.java
@@ -1,18 +1,28 @@
 package com.shinhan_hackathon.the_family_guardian.domain.user.controller;
 
-import com.shinhan_hackathon.the_family_guardian.domain.user.dto.*;
+import com.shinhan_hackathon.the_family_guardian.domain.user.dto.AccountAuthCheckRequest;
+import com.shinhan_hackathon.the_family_guardian.domain.user.dto.AccountAuthResponse;
+import com.shinhan_hackathon.the_family_guardian.domain.user.dto.AccountAuthSendRequest;
+import com.shinhan_hackathon.the_family_guardian.domain.user.dto.SignupRequest;
+import com.shinhan_hackathon.the_family_guardian.domain.user.dto.UpdateDeviceTokenRequest;
+import com.shinhan_hackathon.the_family_guardian.domain.user.dto.UpdateDeviceTokenResponse;
+import com.shinhan_hackathon.the_family_guardian.domain.user.dto.UserInfoResponse;
 import com.shinhan_hackathon.the_family_guardian.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+@Slf4j
 @Controller
 @RequestMapping("/user")
 @RequiredArgsConstructor
 public class UserController {
+
     private final UserService userService;
 
     @PostMapping("/signup")
@@ -22,14 +32,16 @@ public class UserController {
     }
 
     @PostMapping("/accountAuthCode")
-    public ResponseEntity<AccountAuthResponse> sendAccountAuthCode(@RequestBody AccountAuthSendRequest accountAuthSendRequest) {
+    public ResponseEntity<AccountAuthResponse> sendAccountAuthCode(
+            @RequestBody AccountAuthSendRequest accountAuthSendRequest) {
 
         AccountAuthResponse accountAuthResponse = userService.openAccountAuth(accountAuthSendRequest.accountNumber());
         return ResponseEntity.ok(accountAuthResponse);
     }
 
     @PostMapping("/accountAuthCode/check")
-    public ResponseEntity<AccountAuthResponse> checkAccountAuthCode(@RequestBody AccountAuthCheckRequest accountAuthCheckRequest) {
+    public ResponseEntity<AccountAuthResponse> checkAccountAuthCode(
+            @RequestBody AccountAuthCheckRequest accountAuthCheckRequest) {
         AccountAuthResponse accountAuthSendResponse = userService.checkAccountAuth(
                 accountAuthCheckRequest.accountNumber(),
                 accountAuthCheckRequest.authCode(),
@@ -39,8 +51,18 @@ public class UserController {
     }
 
     @PostMapping("/deviceToken")
-    public ResponseEntity<UpdateDeviceTokenResponse> updateDeviceToken(@RequestBody UpdateDeviceTokenRequest updateDeviceTokenRequest) {
-        UpdateDeviceTokenResponse updateDeviceTokenResponse = userService.setDeviceToken(updateDeviceTokenRequest.deviceToken());
+    public ResponseEntity<UpdateDeviceTokenResponse> updateDeviceToken(
+            @RequestBody UpdateDeviceTokenRequest updateDeviceTokenRequest) {
+        UpdateDeviceTokenResponse updateDeviceTokenResponse = userService.setDeviceToken(
+                updateDeviceTokenRequest.deviceToken());
         return ResponseEntity.ok(updateDeviceTokenResponse);
+    }
+
+    @GetMapping("/info")
+    public ResponseEntity<?> getUserInfo() {
+        log.info("UserController.getUserInfo() is called.");
+        UserInfoResponse userInfo = userService.getUserInfo();
+
+        return ResponseEntity.ok(userInfo);
     }
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/dto/UserInfoResponse.java
@@ -1,0 +1,16 @@
+package com.shinhan_hackathon.the_family_guardian.domain.user.dto;
+
+import com.shinhan_hackathon.the_family_guardian.domain.user.entity.Level;
+import com.shinhan_hackathon.the_family_guardian.domain.user.entity.Role;
+import lombok.Builder;
+
+@Builder
+public record UserInfoResponse(
+        String name,
+        Level level,
+        Role role,
+        Long familyId,
+        String familyName
+) {
+
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/service/UserService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/service/UserService.java
@@ -13,8 +13,10 @@ import com.shinhan_hackathon.the_family_guardian.domain.payment.service.PaymentL
 import com.shinhan_hackathon.the_family_guardian.domain.user.dto.AccountAuthResponse;
 import com.shinhan_hackathon.the_family_guardian.domain.user.dto.SignupRequest;
 import com.shinhan_hackathon.the_family_guardian.domain.user.dto.UpdateDeviceTokenResponse;
+import com.shinhan_hackathon.the_family_guardian.domain.user.dto.UserInfoResponse;
 import com.shinhan_hackathon.the_family_guardian.domain.user.entity.User;
 import com.shinhan_hackathon.the_family_guardian.domain.user.repository.UserRepository;
+import com.shinhan_hackathon.the_family_guardian.global.auth.dto.UserPrincipal;
 import com.shinhan_hackathon.the_family_guardian.global.auth.util.AuthUtil;
 import com.shinhan_hackathon.the_family_guardian.global.redis.service.RedisService;
 import java.sql.Timestamp;
@@ -27,6 +29,8 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -197,6 +201,25 @@ public class UserService {
             }
             default -> throw new IllegalArgumentException("Unknown period: " + period);
         }
+    }
+
+    public Long getUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+        return userPrincipal.user().getId();
+    }
+
+    public UserInfoResponse getUserInfo() {
+        log.info("UserService.getUserInfo() is called.");
+        User user = getUser(getUserId());
+
+        return UserInfoResponse.builder()
+                .name(user.getName())
+                .level(user.getLevel())
+                .role(user.getRole())
+                .familyId(user.getFamily().getId())
+                .familyName(user.getFamily().getName())
+                .build();
     }
 
     // TODO: PaymentLimitList 조회


### PR DESCRIPTION
## 연결 이슈 <!-- 연결 이슈 번호를 작성해주세요. Ex. tomato-market/plan#3)  -->

- #72 

## 요약 <!-- 현재 PR의 요약 내용을 작성해주세요. -->

- 메인화면에 표시될 사용자 정보 조회 API 추가

## 변경 내용 <!-- 현재 PR의 변경 내용을 작성해주세요. -->

- `UserController.getUserInfo()`
- `UserService.getUserInfo()`
- `UserInfoReponse`

## 기타 <!-- 기타 공유할 내용이 있다면 작성해주세요. -->

-
