### PR TITLE
[Feat/#75] Notification 관련 api 추가

### DIFF
--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/approval/repository/ApprovalRepository.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/approval/repository/ApprovalRepository.java
@@ -4,9 +4,12 @@ import com.shinhan_hackathon.the_family_guardian.domain.approval.entity.Approval
 import com.shinhan_hackathon.the_family_guardian.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ApprovalRepository extends JpaRepository<Approval, Long> {
     boolean existsByUser(User user);
     Optional<Approval> findByUser(User user);
+
+    List<Approval> findAllByUser(User user);
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/controller/FamilyController.java
@@ -1,5 +1,6 @@
 package com.shinhan_hackathon.the_family_guardian.domain.family.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.shinhan_hackathon.the_family_guardian.domain.family.dto.*;
 import com.shinhan_hackathon.the_family_guardian.domain.family.service.FamilyService;
 import com.shinhan_hackathon.the_family_guardian.domain.user.entity.Level;
@@ -40,7 +41,7 @@ public class FamilyController {
     }
 
     @PostMapping("/{family_id}/invite")
-    public ResponseEntity<AddFamilyMemberResponse> addFamilyMember(@PathVariable(value = "family_id") Long family_id, @RequestBody AddFamilyMemberRequest addFamilyMemberRequest) {
+    public ResponseEntity<AddFamilyMemberResponse> addFamilyMember(@PathVariable(value = "family_id") Long family_id, @RequestBody AddFamilyMemberRequest addFamilyMemberRequest) throws JsonProcessingException {
         authUtil.checkAuthority(Role.OWNER);
 
         AddFamilyMemberResponse addFamilyMemberResponse = familyService.registerMember(family_id, addFamilyMemberRequest);

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/FamilyInfoResponse.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/FamilyInfoResponse.java
@@ -16,7 +16,7 @@ public record FamilyInfoResponse (
     public record FamilyUser (
             Long id,
             String name,
-            LocalDate birthDate,
+            String birthDate,
             Level level,
             Role role,
             String relationship

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/FamilyInfoResponse.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/FamilyInfoResponse.java
@@ -3,6 +3,7 @@ package com.shinhan_hackathon.the_family_guardian.domain.family.dto;
 import com.shinhan_hackathon.the_family_guardian.domain.user.entity.Level;
 import com.shinhan_hackathon.the_family_guardian.domain.user.entity.Role;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public record FamilyInfoResponse (
@@ -15,7 +16,7 @@ public record FamilyInfoResponse (
     public record FamilyUser (
             Long id,
             String name,
-            String phoneNumber,
+            LocalDate birthDate,
             Level level,
             Role role,
             String relationship

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/FamilyInviteNotification.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/FamilyInviteNotification.java
@@ -1,0 +1,10 @@
+package com.shinhan_hackathon.the_family_guardian.domain.family.dto;
+
+public record FamilyInviteNotification (
+        Long id,
+        String name,
+        String description,
+        Long ownerId,
+        String ownerName
+) {
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
@@ -1,5 +1,7 @@
 package com.shinhan_hackathon.the_family_guardian.domain.family.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.shinhan_hackathon.the_family_guardian.domain.approval.service.ApprovalService;
 import com.shinhan_hackathon.the_family_guardian.domain.family.dto.*;
 import com.shinhan_hackathon.the_family_guardian.domain.family.entity.Family;
@@ -10,6 +12,7 @@ import com.shinhan_hackathon.the_family_guardian.domain.user.repository.UserRepo
 import com.shinhan_hackathon.the_family_guardian.domain.user.service.UserService;
 import com.shinhan_hackathon.the_family_guardian.global.auth.dto.UserPrincipal;
 import com.shinhan_hackathon.the_family_guardian.global.auth.util.AuthUtil;
+import com.shinhan_hackathon.the_family_guardian.global.fcm.FcmSender;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
@@ -30,6 +33,8 @@ public class FamilyService {
     private final AuthUtil authUtil;
     private final ApprovalService approvalService;
     private final UserService userService;
+    private final FcmSender fcmSender;
+    private final ObjectMapper jacksonObjectMapper;
 
     @Transactional
     public CreateFamilyResponse registerFamily(CreateFamilyRequest createFamilyRequest) {
@@ -131,7 +136,7 @@ public class FamilyService {
     }
 
     @Transactional
-    public AddFamilyMemberResponse registerMember(Long familyId, AddFamilyMemberRequest addFamilyMemberRequest) {
+    public AddFamilyMemberResponse registerMember(Long familyId, AddFamilyMemberRequest addFamilyMemberRequest) throws JsonProcessingException {
         Family family = authUtil.getUserPrincipal().getFamily();
         if (!family.getId().equals(familyId)) {
             throw new AccessDeniedException("소속된 가족이 아닙니다.");
@@ -142,7 +147,16 @@ public class FamilyService {
             throw new RuntimeException("소속된 가족이 있는 사용자입니다.");
         }
 
-        // TODO: Send Notification to invited user
+        Long ownerId = Long.valueOf(authUtil.getUserPrincipal().getUsername());
+        User owner = userRepository.findById(ownerId).orElseThrow(() -> new RuntimeException("유저가 없습니다."));
+
+        FamilyInviteNotification familyInviteNotification = new FamilyInviteNotification(user.getId(), user.getName(), family.getDescription(), ownerId, owner.getName());
+        String notificationBody = jacksonObjectMapper.writeValueAsString(familyInviteNotification);
+        fcmSender.sendMessage(
+                user.getDeviceToken(),
+                "가족 초대 알림",
+                notificationBody
+        );
 
         Long approvalId = approvalService.createApproval(family, user);
         return new AddFamilyMemberResponse(

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
@@ -19,6 +19,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -86,7 +87,7 @@ public class FamilyService {
                 .map(user -> new FamilyInfoResponse.FamilyUser(
                         user.getId(),
                         user.getName(),
-                        user.getBirthDate(),
+                        user.getBirthDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")),
                         user.getLevel(),
                         user.getRole(),
                         user.getRelationship())

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
@@ -86,7 +86,7 @@ public class FamilyService {
                 .map(user -> new FamilyInfoResponse.FamilyUser(
                         user.getId(),
                         user.getName(),
-                        user.getPhone(),
+                        user.getBirthDate(),
                         user.getLevel(),
                         user.getRole(),
                         user.getRelationship())

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/controller/NotificationController.java
@@ -31,10 +31,10 @@ public class NotificationController {
         return ResponseEntity.ok(notificationReplyResponse);
     }
 
-    @GetMapping("/group/{group_id}")
-    public ResponseEntity<PendingNotificationResponse> getPendingNotification(@PathVariable Long group_id) {
+    @GetMapping("/unanswered}")
+    public ResponseEntity<PendingNotificationResponse> getPendingNotification() {
         authUtil.checkAuthority(Role.MANAGER, Role.OWNER);
-        PendingNotificationResponse pendingNotification = notificationService.getPendingNotification(group_id);
+        PendingNotificationResponse pendingNotification = notificationService.findUnansweredNotification();
         return ResponseEntity.ok(pendingNotification);
     }
 

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/controller/NotificationController.java
@@ -5,6 +5,7 @@ import com.shinhan_hackathon.the_family_guardian.domain.notification.dto.Notific
 import com.shinhan_hackathon.the_family_guardian.domain.notification.dto.NotificationReplyResponse;
 import com.shinhan_hackathon.the_family_guardian.domain.notification.dto.PendingNotificationResponse;
 import com.shinhan_hackathon.the_family_guardian.domain.notification.service.NotificationService;
+import com.shinhan_hackathon.the_family_guardian.domain.transaction.dto.NotificationBody;
 import com.shinhan_hackathon.the_family_guardian.domain.user.entity.Role;
 import com.shinhan_hackathon.the_family_guardian.global.auth.util.AuthUtil;
 import lombok.RequiredArgsConstructor;
@@ -41,5 +42,13 @@ public class NotificationController {
     public ResponseEntity<List<NotificationHistory>> getUserNotification(@PathVariable(value = "user_id") Long userId) {
         List<NotificationHistory> notificationByUserId = notificationService.findNotificationByUserId(userId);
         return ResponseEntity.ok(notificationByUserId);
+    }
+
+    @GetMapping("/{notification_id}")
+    public ResponseEntity<NotificationBody> getNotification(@PathVariable(value = "notification_id") Long notificationId) {
+        authUtil.checkAuthority(Role.MANAGER, Role.OWNER);
+
+        NotificationBody notificationBody = notificationService.findNotification(notificationId);
+        return ResponseEntity.ok(notificationBody);
     }
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/controller/NotificationController.java
@@ -31,7 +31,7 @@ public class NotificationController {
         return ResponseEntity.ok(notificationReplyResponse);
     }
 
-    @GetMapping("/unanswered}")
+    @GetMapping("/unanswered")
     public ResponseEntity<PendingNotificationResponse> getPendingNotification() {
         authUtil.checkAuthority(Role.MANAGER, Role.OWNER);
         PendingNotificationResponse pendingNotification = notificationService.findUnansweredNotification();

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/controller/NotificationController.java
@@ -1,5 +1,6 @@
 package com.shinhan_hackathon.the_family_guardian.domain.notification.controller;
 
+import com.shinhan_hackathon.the_family_guardian.domain.notification.dto.NotificationHistory;
 import com.shinhan_hackathon.the_family_guardian.domain.notification.dto.NotificationReplyRequest;
 import com.shinhan_hackathon.the_family_guardian.domain.notification.dto.NotificationReplyResponse;
 import com.shinhan_hackathon.the_family_guardian.domain.notification.dto.PendingNotificationResponse;
@@ -9,6 +10,8 @@ import com.shinhan_hackathon.the_family_guardian.global.auth.util.AuthUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -32,5 +35,11 @@ public class NotificationController {
         authUtil.checkAuthority(Role.MANAGER, Role.OWNER);
         PendingNotificationResponse pendingNotification = notificationService.getPendingNotification(group_id);
         return ResponseEntity.ok(pendingNotification);
+    }
+
+    @GetMapping("/user/{user_id}")
+    public ResponseEntity<List<NotificationHistory>> getUserNotification(@PathVariable(value = "user_id") Long userId) {
+        List<NotificationHistory> notificationByUserId = notificationService.findNotificationByUserId(userId);
+        return ResponseEntity.ok(notificationByUserId);
     }
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/dto/NotificationHistory.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/dto/NotificationHistory.java
@@ -1,0 +1,10 @@
+package com.shinhan_hackathon.the_family_guardian.domain.notification.dto;
+
+import com.shinhan_hackathon.the_family_guardian.domain.transaction.entity.TransactionType;
+
+public record NotificationHistory(
+        Long notificationId,
+        TransactionType transactionType,
+        Long transactionBalance
+) {
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/entity/NotificationResponseStatus.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/entity/NotificationResponseStatus.java
@@ -37,4 +37,8 @@ public class NotificationResponseStatus {
         this.notification = notification;
         this.responseStatus = responseStatus;
     }
+
+    public ResponseStatus updateResponseStatus(ResponseStatus responseStatus) {
+        return this.responseStatus = responseStatus;
+    }
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/repository/NotificationRepository.java
@@ -1,6 +1,7 @@
 package com.shinhan_hackathon.the_family_guardian.domain.notification.repository;
 
 import com.shinhan_hackathon.the_family_guardian.domain.notification.entity.Notification;
+import com.shinhan_hackathon.the_family_guardian.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -9,4 +10,6 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     @Query(value = "select * from notification where user_id = :userId", nativeQuery = true)
     List<Notification> findByUserId(Long userId);
+
+    List<Notification> findAllByUser(User user);
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/repository/NotificationResponseStatusRepository.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/repository/NotificationResponseStatusRepository.java
@@ -1,0 +1,12 @@
+package com.shinhan_hackathon.the_family_guardian.domain.notification.repository;
+
+import com.shinhan_hackathon.the_family_guardian.domain.notification.entity.Notification;
+import com.shinhan_hackathon.the_family_guardian.domain.notification.entity.NotificationResponseStatus;
+import com.shinhan_hackathon.the_family_guardian.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NotificationResponseStatusRepository extends JpaRepository<NotificationResponseStatus, Long> {
+    Optional<NotificationResponseStatus> findByGuardianAndNotification(User guardian, Notification notification);
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/repository/NotificationResponseStatusRepository.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/repository/NotificationResponseStatusRepository.java
@@ -2,11 +2,15 @@ package com.shinhan_hackathon.the_family_guardian.domain.notification.repository
 
 import com.shinhan_hackathon.the_family_guardian.domain.notification.entity.Notification;
 import com.shinhan_hackathon.the_family_guardian.domain.notification.entity.NotificationResponseStatus;
+import com.shinhan_hackathon.the_family_guardian.domain.notification.entity.ResponseStatus;
 import com.shinhan_hackathon.the_family_guardian.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface NotificationResponseStatusRepository extends JpaRepository<NotificationResponseStatus, Long> {
     Optional<NotificationResponseStatus> findByGuardianAndNotification(User guardian, Notification notification);
+
+    List<NotificationResponseStatus> findAllByGuardianAndResponseStatus(User guardian, ResponseStatus responseStatus);
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/service/NotificationService.java
@@ -48,7 +48,7 @@ public class NotificationService {
     private final AuthUtil authUtil;
 
     @Transactional
-    public NotificationBody saveNotification(TransactionInfo transactionInfo) {
+    public Notification saveNotification(TransactionInfo transactionInfo) {
 
         NotificationBody notificationBody = new NotificationBody(
                 transactionInfo.transaction().getId(),
@@ -67,8 +67,7 @@ public class NotificationService {
                 .requiresResponse(true)
                 .build();
 
-        notificationRepository.save(notification);
-        return notificationBody;
+        return notificationRepository.save(notification);
     }
 
     @Transactional

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/notification/service/NotificationService.java
@@ -2,6 +2,7 @@ package com.shinhan_hackathon.the_family_guardian.domain.notification.service;
 
 import com.shinhan_hackathon.the_family_guardian.domain.family.entity.Family;
 import com.shinhan_hackathon.the_family_guardian.domain.family.service.FamilyService;
+import com.shinhan_hackathon.the_family_guardian.domain.notification.dto.NotificationHistory;
 import com.shinhan_hackathon.the_family_guardian.domain.notification.dto.NotificationReplyResponse;
 import com.shinhan_hackathon.the_family_guardian.domain.notification.dto.PendingNotification;
 import com.shinhan_hackathon.the_family_guardian.domain.notification.dto.PendingNotificationResponse;
@@ -39,6 +40,7 @@ public class NotificationService {
     private final FamilyService familyService;
     private final EventPublisher eventPublisher;
     private final TransactionRepository transactionRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public NotificationBody saveNotification(TransactionInfo transactionInfo) {
@@ -117,5 +119,20 @@ public class NotificationService {
         }
         PendingNotificationResponse response = new PendingNotificationResponse(list);
         return response;
+    }
+
+    public List<NotificationHistory> findNotificationByUserId(Long userId) {
+        User user = userRepository.getReferenceById(userId);
+        List<Notification> notificationList = notificationRepository.findAllByUser(user);
+
+
+        return notificationList.stream().map(notification -> {
+            Transaction transaction = notification.getTransaction();
+            return new NotificationHistory(
+                    notification.getId(),
+                    transaction.getTransactionType(),
+                    transaction.getTransactionBalance()
+            );
+        }).toList();
     }
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/service/TransactionService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/transaction/service/TransactionService.java
@@ -2,8 +2,11 @@ package com.shinhan_hackathon.the_family_guardian.domain.transaction.service;
 
 import com.shinhan_hackathon.the_family_guardian.bank.dto.response.AccountTransactionHistoryListResponse;
 import com.shinhan_hackathon.the_family_guardian.bank.service.AccountService;
+import com.shinhan_hackathon.the_family_guardian.domain.notification.entity.Notification;
+import com.shinhan_hackathon.the_family_guardian.domain.notification.entity.NotificationResponseStatus;
 import com.shinhan_hackathon.the_family_guardian.domain.notification.entity.PaymentLimitType;
 import com.shinhan_hackathon.the_family_guardian.domain.notification.entity.ResponseStatus;
+import com.shinhan_hackathon.the_family_guardian.domain.notification.repository.NotificationResponseStatusRepository;
 import com.shinhan_hackathon.the_family_guardian.domain.notification.service.NotificationService;
 import com.shinhan_hackathon.the_family_guardian.domain.payment.service.PaymentLimitService;
 import com.shinhan_hackathon.the_family_guardian.domain.transaction.dto.*;
@@ -51,6 +54,7 @@ public class TransactionService {
     private final NotificationService notificationService;
     private final List<Role> familyGuardianRole = List.of(Role.MANAGER, Role.OWNER);
     private final int TIMEOUT = 10;
+    private final NotificationResponseStatusRepository notificationResponseStatusRepository;
 
     public List<TransactionResponse> getTransactionHistory(Long userId, Pageable pageable) {
         log.info("TransactionService.getTransactionHistory() is called.");
@@ -266,14 +270,20 @@ public class TransactionService {
     }
 
     // Guardian에게 승인 메시지 전송
-    private void sendGuardianApprovalMessage(User user, Transaction transaction, PaymentLimitType paymentLimitType) {
+    @Transactional
+    protected void sendGuardianApprovalMessage(User user, Transaction transaction, PaymentLimitType paymentLimitType) {
         TransactionInfo transactionInfo = new TransactionInfo(user, transaction, paymentLimitType);
-        NotificationBody notificationBody = notificationService.saveNotification(transactionInfo);
+        Notification notification = notificationService.saveNotification(transactionInfo);
 
-        List<String> guardianDeviceToken = user.getFamily().getUsers().stream()
-                .filter(familyUser -> familyGuardianRole.contains(familyUser.getRole()))
-                .map(User::getDeviceToken).toList();
-        fcmSender.sendApprovalNotification(guardianDeviceToken, notificationBody);
+        List<User> guardianList = user.getFamily().getUsers().stream()
+                .filter(familyUser -> familyGuardianRole.contains(familyUser.getRole())).toList();
+
+        List<NotificationResponseStatus> responseStatusList = guardianList.stream()
+                .map(guardian -> new NotificationResponseStatus(guardian, notification, ResponseStatus.NONE)).toList();
+        notificationResponseStatusRepository.saveAll(responseStatusList);
+
+        List<String> guardianDeviceToken = guardianList.stream().map(guardian -> guardian.getDeviceToken()).toList();
+        fcmSender.sendApprovalNotification(guardianDeviceToken, notification.getBody());
     }
 
     // TODO: 시간제한에 걸려 자동으로 요청 취소

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/controller/UserController.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.shinhan_hackathon.the_family_guardian.domain.user.controller;
 
+import com.shinhan_hackathon.the_family_guardian.domain.family.dto.FamilyInviteNotification;
 import com.shinhan_hackathon.the_family_guardian.domain.user.dto.AccountAuthCheckRequest;
 import com.shinhan_hackathon.the_family_guardian.domain.user.dto.AccountAuthResponse;
 import com.shinhan_hackathon.the_family_guardian.domain.user.dto.AccountAuthSendRequest;
@@ -8,6 +9,7 @@ import com.shinhan_hackathon.the_family_guardian.domain.user.dto.UpdateDeviceTok
 import com.shinhan_hackathon.the_family_guardian.domain.user.dto.UpdateDeviceTokenResponse;
 import com.shinhan_hackathon.the_family_guardian.domain.user.dto.UserInfoResponse;
 import com.shinhan_hackathon.the_family_guardian.domain.user.service.UserService;
+import com.shinhan_hackathon.the_family_guardian.global.auth.util.AuthUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +19,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import java.util.List;
+
 @Slf4j
 @Controller
 @RequestMapping("/user")
@@ -24,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class UserController {
 
     private final UserService userService;
+    private final AuthUtil authUtil;
 
     @PostMapping("/signup")
     public ResponseEntity<String> signup(@RequestBody SignupRequest signupRequest) {
@@ -64,5 +69,11 @@ public class UserController {
         UserInfoResponse userInfo = userService.getUserInfo();
 
         return ResponseEntity.ok(userInfo);
+    }
+
+    @GetMapping("/invite")
+    public ResponseEntity<List<FamilyInviteNotification>> getFamilyInviteRequest() {
+        List<FamilyInviteNotification> familyInviteList = userService.findFamilyInviteRequest();
+        return ResponseEntity.ok(familyInviteList);
     }
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/user/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package com.shinhan_hackathon.the_family_guardian.domain.user.repository;
 
+import com.shinhan_hackathon.the_family_guardian.domain.family.entity.Family;
+import com.shinhan_hackathon.the_family_guardian.domain.user.entity.Role;
 import com.shinhan_hackathon.the_family_guardian.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
 
     Optional<User> findByPhone(String phoneNUmber);
+
+    Optional<User> findByFamilyAndRole(Family family, Role role);
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/global/fcm/FcmSender.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/global/fcm/FcmSender.java
@@ -1,5 +1,7 @@
 package com.shinhan_hackathon.the_family_guardian.global.fcm;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.core.ApiFuture;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
@@ -20,6 +22,7 @@ import java.util.concurrent.Executor;
 @RequiredArgsConstructor
 @Component
 public class FcmSender implements MessageSender {
+    private final ObjectMapper jacksonObjectMapper;
     @Value("${firebase.app-name}")
     private String firebaseAppName;
 
@@ -56,9 +59,14 @@ public class FcmSender implements MessageSender {
     }
 
     public void sendApprovalNotification(List<String> guardianDeviceTokenList, NotificationBody body) {
-        guardianDeviceTokenList.forEach(deviceToken ->
-                sendMessage(deviceToken, "승인 요청", body.toString())
-        );
+        for (String deviceToken : guardianDeviceTokenList) {
+            try {
+                sendMessage(deviceToken, "승인 요청", jacksonObjectMapper.writeValueAsString(body));
+            } catch (JsonProcessingException e) {
+                log.error("fcm 전송 실패 deviceToken: {}", deviceToken);
+                e.printStackTrace();
+            }
+        }
     }
 
     // public: FCM 접근 메서드

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/global/fcm/FcmSender.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/global/fcm/FcmSender.java
@@ -58,14 +58,9 @@ public class FcmSender implements MessageSender {
         };
     }
 
-    public void sendApprovalNotification(List<String> guardianDeviceTokenList, NotificationBody body) {
+    public void sendApprovalNotification(List<String> guardianDeviceTokenList, String body) {
         for (String deviceToken : guardianDeviceTokenList) {
-            try {
-                sendMessage(deviceToken, "승인 요청", jacksonObjectMapper.writeValueAsString(body));
-            } catch (JsonProcessingException e) {
-                log.error("fcm 전송 실패 deviceToken: {}", deviceToken);
-                e.printStackTrace();
-            }
+            sendMessage(deviceToken, "승인 요청", body);
         }
     }
 


### PR DESCRIPTION
## 연결 이슈 <!-- 연결 이슈 번호를 작성해주세요. Ex. tomato-market/plan#3)  -->

- resolve: #75 

## 요약 <!-- 현재 PR의 요약 내용을 작성해주세요. -->

- 알림 관련 api 추가

## 변경 내용 <!-- 현재 PR의 변경 내용을 작성해주세요. -->

- 서포터의 대기중인 요청들 조회
- 대기중인 요청(알림) 객체 조회
- 가디언의 미응답 알림 조회
- 가족 초대 알림 조회
