### PR TITLE
[Feat/#98] 그룹 도메인 추가 api 개발

### DIFF
--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/chatbot/controller/ChatController.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/chatbot/controller/ChatController.java
@@ -37,7 +37,7 @@ public class ChatController {
 				"보호하고 있어. 그리고 서포터들의 사용 금액을 모니터링하며 관리해줄 수도 있어. 이제부터 금융상식이나 우리 '더 패밀리 가디언" +
 				"에 대해서 질문을 할건데 너가 묻는 말에 친절하게 대답을 해줘. 그리고 너가 누구냐는 식의 질문 외에는 너의 소개는 하지 않아도 돼! 이제 질문할게! \n";
 		String vertexAiGeminiResponse = vertexAiGeminiChatModel.call(prompt + message);
-		responses.put("Guardi의 응답", vertexAiGeminiResponse);
+		responses.put("message", vertexAiGeminiResponse);
 
 		chatService.saveMessage(getUserId(), message.message(), true);
 		chatService.saveMessage(getUserId(), vertexAiGeminiResponse, false);

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/controller/FamilyController.java
@@ -20,7 +20,7 @@ public class FamilyController {
 
     @GetMapping("/{family_id}")
     public ResponseEntity<FamilyInfoResponse> getFamilyInfoById(@PathVariable(value = "family_id") Long familyId) {
-        FamilyInfoResponse familyInfo = familyService.getFamilyInfo(familyId);
+        FamilyInfoResponse familyInfo = familyService.findFamilyInfo(familyId);
         return ResponseEntity.ok(familyInfo);
     }
 

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/controller/FamilyController.java
@@ -40,6 +40,12 @@ public class FamilyController {
         return ResponseEntity.ok(updateFamilyResponse);
     }
 
+    @GetMapping("/{family_id}/users")
+    public ResponseEntity<FamilyUserResponse> getFamilyUsers(@PathVariable(value = "family_id") Long familyId) {
+        FamilyUserResponse familyUsers = familyService.findFamilyUsers(familyId);
+        return ResponseEntity.ok(familyUsers);
+    }
+
     @PostMapping("/{family_id}/invite")
     public ResponseEntity<AddFamilyMemberResponse> addFamilyMember(@PathVariable(value = "family_id") Long family_id, @RequestBody AddFamilyMemberRequest addFamilyMemberRequest) throws JsonProcessingException {
         authUtil.checkAuthority(Role.OWNER);

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/FamilyInfoResponse.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/FamilyInfoResponse.java
@@ -1,11 +1,9 @@
 package com.shinhan_hackathon.the_family_guardian.domain.family.dto;
 
-import java.time.LocalDate;
-
 public record FamilyInfoResponse (
         String name,
         String description,
         Integer approvalRequest,
-        LocalDate createdAt
+        String createdAt
 ) {
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/FamilyInfoResponse.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/FamilyInfoResponse.java
@@ -1,25 +1,11 @@
 package com.shinhan_hackathon.the_family_guardian.domain.family.dto;
 
-import com.shinhan_hackathon.the_family_guardian.domain.user.entity.Level;
-import com.shinhan_hackathon.the_family_guardian.domain.user.entity.Role;
-
 import java.time.LocalDate;
-import java.util.List;
 
 public record FamilyInfoResponse (
         String name,
         String description,
         Integer approvalRequest,
-        List<FamilyUser> userList
+        LocalDate createdAt
 ) {
-
-    public record FamilyUser (
-            Long id,
-            String name,
-            String birthDate,
-            Level level,
-            Role role,
-            String relationship
-    ) {
-    }
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/FamilyUserResponse.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/FamilyUserResponse.java
@@ -1,0 +1,21 @@
+package com.shinhan_hackathon.the_family_guardian.domain.family.dto;
+
+import com.shinhan_hackathon.the_family_guardian.domain.user.entity.Level;
+import com.shinhan_hackathon.the_family_guardian.domain.user.entity.Role;
+
+import java.util.List;
+
+public record FamilyUserResponse(
+        List<FamilyUser> userList
+) {
+
+    public record FamilyUser (
+            Long id,
+            String name,
+            String birthDate,
+            Level level,
+            Role role,
+            String relationship
+    ) {
+    }
+}

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/FamilyUserResponse.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/dto/FamilyUserResponse.java
@@ -12,7 +12,7 @@ public record FamilyUserResponse(
     public record FamilyUser (
             Long id,
             String name,
-            String birthDate,
+            String birthdate,
             Level level,
             Role role,
             String relationship

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/entity/Family.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/entity/Family.java
@@ -34,16 +34,16 @@ public class Family {
     private Integer totalManagerCount; // TODO: Default로 Owner가 있으니까 1? default 0에서 그룹 생성할 때 owner 등록하면서 +1?
 
     @Column(nullable = false)
-    private LocalDate created_at;
+    private LocalDate createdAt;
 
     @Builder
-    public Family(String name, String description, int approvalRequirement, List<User> users, Integer totalManagerCount, LocalDate created_at) {
+    public Family(String name, String description, int approvalRequirement, List<User> users, Integer totalManagerCount, LocalDate createdAt) {
         this.name = name;
         this.description = description;
         this.approvalRequirement = approvalRequirement;
         this.users = users;
         this.totalManagerCount = totalManagerCount;
-        this.created_at = created_at;
+        this.createdAt = createdAt;
     }
 
     public int increaseTotalManagerCount() {

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/entity/Family.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/entity/Family.java
@@ -4,6 +4,7 @@ import com.shinhan_hackathon.the_family_guardian.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Entity
@@ -32,13 +33,17 @@ public class Family {
     @Column(nullable = false)
     private Integer totalManagerCount; // TODO: Default로 Owner가 있으니까 1? default 0에서 그룹 생성할 때 owner 등록하면서 +1?
 
+    @Column(nullable = false)
+    private LocalDate created_at;
+
     @Builder
-    public Family(String name, String description, int approvalRequirement, List<User> users, Integer totalManagerCount) {
+    public Family(String name, String description, int approvalRequirement, List<User> users, Integer totalManagerCount, LocalDate created_at) {
         this.name = name;
         this.description = description;
         this.approvalRequirement = approvalRequirement;
         this.users = users;
         this.totalManagerCount = totalManagerCount;
+        this.created_at = created_at;
     }
 
     public int increaseTotalManagerCount() {

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
@@ -19,6 +19,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,6 +56,7 @@ public class FamilyService {
                 .approvalRequirement(createFamilyRequest.approvalRequirement())
                 .users(new ArrayList<>(List.of(user)))
                 .totalManagerCount(1)
+                .created_at(LocalDate.now(ZoneId.systemDefault()))
                 .build();
 
         Family savedFamily = familyRepository.save(family);

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -204,5 +205,23 @@ public class FamilyService {
         Family family = familyRepository.findById(groupId)
                 .orElseThrow(EntityNotFoundException::new);
         return family;
+    }
+
+
+    public FamilyUserResponse findFamilyUsers(Long familyId) {
+        isValidFamilyUser(familyId);
+
+        Family family = getFamilyFromDatabase(familyId);
+        List<FamilyUserResponse.FamilyUser> familyUserList = family.getUsers().stream().map(user -> new FamilyUserResponse.FamilyUser(
+                user.getId(),
+                user.getName(),
+                user.getBirthDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")),
+                user.getLevel(),
+                user.getRole(),
+                user.getRelationship()
+        )).toList();
+
+        return new FamilyUserResponse(familyUserList);
+
     }
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
@@ -106,7 +106,7 @@ public class FamilyService {
             throw new AccessDeniedException("소속된 가족이 아닙니다.");
         }
 
-        Family family = familyRepository.findById(1L)
+        Family family = familyRepository.findById(familyId)
                 .orElseThrow(() -> new RuntimeException("소속된 가족이 없습니다."));
 
         if (!family.getName().equals(updateFamilyRequest.name())) {

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
@@ -79,7 +79,7 @@ public class FamilyService {
                 family.getName(),
                 family.getDescription(),
                 family.getApprovalRequirement(),
-                family.getCreatedAt()
+                family.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"))
         );
     }
 

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/family/service/FamilyService.java
@@ -56,7 +56,7 @@ public class FamilyService {
                 .approvalRequirement(createFamilyRequest.approvalRequirement())
                 .users(new ArrayList<>(List.of(user)))
                 .totalManagerCount(1)
-                .created_at(LocalDate.now(ZoneId.systemDefault()))
+                .createdAt(LocalDate.now(ZoneId.systemDefault()))
                 .build();
 
         Family savedFamily = familyRepository.save(family);
@@ -86,21 +86,11 @@ public class FamilyService {
         }
 
         Family family = getFamilyFromDatabase(familyId);
-        List<FamilyInfoResponse.FamilyUser> familyUserList = family.getUsers().stream()
-                .map(user -> new FamilyInfoResponse.FamilyUser(
-                        user.getId(),
-                        user.getName(),
-                        user.getBirthDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")),
-                        user.getLevel(),
-                        user.getRole(),
-                        user.getRelationship())
-                )
-                .toList();
         return new FamilyInfoResponse(
                 family.getName(),
                 family.getDescription(),
                 family.getApprovalRequirement(),
-                familyUserList
+                family.getCreatedAt()
         );
     }
     private Family getFamilyFromDatabase(Long familyId) {

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/payment/controller/PaymentLimitController.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/payment/controller/PaymentLimitController.java
@@ -2,15 +2,13 @@ package com.shinhan_hackathon.the_family_guardian.domain.payment.controller;
 
 import com.shinhan_hackathon.the_family_guardian.domain.payment.dto.UpdateLimitRequest;
 import com.shinhan_hackathon.the_family_guardian.domain.payment.dto.UpdateLimitResponse;
+import com.shinhan_hackathon.the_family_guardian.domain.payment.dto.UserLimitResponse;
 import com.shinhan_hackathon.the_family_guardian.domain.payment.service.PaymentLimitService;
 import com.shinhan_hackathon.the_family_guardian.domain.user.entity.Role;
 import com.shinhan_hackathon.the_family_guardian.global.auth.util.AuthUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/limit")
@@ -26,5 +24,12 @@ public class PaymentLimitController {
 
         UpdateLimitResponse updateLimitResponse = paymentLimitService.manageMemberLimit(updateLimitRequest);
         return ResponseEntity.ok(updateLimitResponse);
+    }
+
+    @GetMapping("/user/{user_id}")
+    public ResponseEntity<UserLimitResponse> getMemberLimit(@PathVariable(value = "user_id") Long userId) {
+        authUtil.checkAuthority(Role.OWNER, Role.MANAGER);
+        UserLimitResponse userLimitResponse = paymentLimitService.findPaymentLimit(userId);
+        return ResponseEntity.ok(userLimitResponse);
     }
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/payment/dto/UserLimitResponse.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/payment/dto/UserLimitResponse.java
@@ -1,0 +1,11 @@
+package com.shinhan_hackathon.the_family_guardian.domain.payment.dto;
+
+import com.shinhan_hackathon.the_family_guardian.domain.payment.entity.LimitPeriod;
+
+public record UserLimitResponse(
+        Long targetUserId,
+        LimitPeriod period,
+        Integer singleTransactionLimit,
+        Integer maxLimitAmount
+) {
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -119,8 +119,8 @@ INSERT IGNORE INTO user (id, account_number, birth_date, gender, level, name, pa
 (5, '0885141500369617', '2007-09-08 00:00:00', 'MALE', 'SUPPORTER', '김은우', '3344', '010-4567-8901', '아들', 'MEMBER', 'kimeunwoo@gmail.com', NULL),
 (6, '0886372305629122', '2009-11-22 00:00:00', 'FEMALE', 'SUPPORTER', '김리나', '5566', '010-5678-9012', '딸', 'MEMBER', 'kimrina@gmail.com', NULL);
 
-INSERT IGNORE INTO family (id, approval_requirement, name, description, total_manager_count) VALUES
-(1, 2, "미영이팸", "사랑하는 가족들", 3);
+INSERT IGNORE INTO family (id, approval_requirement, name, description, total_manager_count, created_at) VALUES
+(1, 2, "미영이팸", "사랑하는 가족들", 3, now());
 
 INSERT IGNORE INTO approval (family_id, id, user_id, accepted) VALUES
 (1, 1, 7, "ACCEPT"),


### PR DESCRIPTION
## 연결 이슈 <!-- 연결 이슈 번호를 작성해주세요. Ex. tomato-market/plan#3)  -->

- resolve: #98 

## 요약 <!-- 현재 PR의 요약 내용을 작성해주세요. -->

- 추가 요구사항에 따른 그룹 도메인 api 구현

## 변경 내용 <!-- 현재 PR의 변경 내용을 작성해주세요. -->

-  그룹 정보 조회(이름, 설명, 승인 수, 생성일)
-  그룹 유저 리스트 조회
- 유저 거래차단 Role 조회
