### PR TITLE
[Fix/#110] 가족초대 응답값 반환, 1원인증 알림 body 타입변경

### DIFF
--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/approval/controller/ApprovalController.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/approval/controller/ApprovalController.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/approval")
 @RequiredArgsConstructor
@@ -16,7 +18,7 @@ public class ApprovalController {
     private final ApprovalService approvalService;
 
     @GetMapping
-    public ResponseEntity<ApprovalInfoResponse> searchApproval() {
+    public ResponseEntity<List<ApprovalInfoResponse>> searchApproval() {
         return ResponseEntity.ok(approvalService.getApproval());
     }
 

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/approval/repository/ApprovalRepository.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/approval/repository/ApprovalRepository.java
@@ -1,5 +1,6 @@
 package com.shinhan_hackathon.the_family_guardian.domain.approval.repository;
 
+import com.shinhan_hackathon.the_family_guardian.domain.approval.entity.AcceptStatus;
 import com.shinhan_hackathon.the_family_guardian.domain.approval.entity.Approval;
 import com.shinhan_hackathon.the_family_guardian.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,4 +13,6 @@ public interface ApprovalRepository extends JpaRepository<Approval, Long> {
     Optional<Approval> findByUser(User user);
 
     List<Approval> findAllByUser(User user);
+
+    List<Approval> findAllByUserAndAccepted(User user, AcceptStatus acceptStatus);
 }

--- a/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/approval/service/ApprovalService.java
+++ b/src/main/java/com/shinhan_hackathon/the_family_guardian/domain/approval/service/ApprovalService.java
@@ -16,6 +16,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -52,18 +53,22 @@ public class ApprovalService {
         return approval.getId();
     }
 
-    public ApprovalInfoResponse getApproval() {
+    public List<ApprovalInfoResponse> getApproval() {
         User user = authUtil.getUserPrincipal().user();
-        Approval approval = approvalRepository.findByUser(user)
-                .orElseThrow(() -> new RuntimeException("초대가 없습니다."));
-        Family family = approval.getFamily();
 
-        return new ApprovalInfoResponse(
-                approval.getId(),
-                family.getId(),
-                family.getName(),
-                family.getDescription()
-        );
+        List<Approval> approvalList = approvalRepository.findAllByUserAndAccepted(user, AcceptStatus.PROGRESS);
+
+        List<ApprovalInfoResponse> approvalInfoResponseList = approvalList.stream().map(approval -> {
+            Family family = approval.getFamily();
+            return new ApprovalInfoResponse(
+                    approval.getId(),
+                    family.getId(),
+                    family.getName(),
+                    family.getDescription()
+            );
+        }).toList();
+
+        return approvalInfoResponseList;
     }
 
     @Transactional


### PR DESCRIPTION
## 연결 이슈 <!-- 연결 이슈 번호를 작성해주세요. Ex. tomato-market/plan#3)  -->

- resolve: #110

## 요약 <!-- 현재 PR의 요약 내용을 작성해주세요. -->

- 변경사항 반영

## 변경 내용 <!-- 현재 PR의 변경 내용을 작성해주세요. -->

- 응답하지 않은 가족초대만 반환하도록 수정
- 1원인증 알림의 body 타입을 json으로 변경